### PR TITLE
fix: attachments with no names were failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ module.exports = Eml2Pdf = function (filename) {
 
     this.inlineImages = function() {
         if (eml2pdf.attachments.length > 0){
-            return cid(eml2pdf.htmlmessage, eml2pdf.attachments);
+            return cid(eml2pdf.htmlmessage, eml2pdf.attachments.map((attachment, i) => ({ ...attachment, fileName: attachment.fileName || i.toString() })));
         } else {
             return eml2pdf.htmlmessage;
         }


### PR DESCRIPTION
I had a bunch of EML files with attachments that had no `fileName`s, causing the conversion to throw an error. 

This PR fixes the error, by providing placeholder `fileName`s to attachments when they do not have theirs.