### PR TITLE
Use as a global NPM package (optional)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ typings/
 # dotenv environment variables file
 .env
 
+# vscode
+.vscode
+
+# eml files
+*.eml
+*.eml.pdf

--- a/eml-to-pdf.js
+++ b/eml-to-pdf.js
@@ -1,0 +1,260 @@
+var fs = require( 'fs' );
+var pdf = require( 'html-pdf' );
+var Envelope = require( 'envelope' );
+var path = require('path');
+var sanitize = require("sanitize-filename");
+var dateFormat = require('dateformat');
+var cid = require('npm-cid');
+var Handlebars = require('handlebars');
+const Entities = require('html-entities').AllHtmlEntities;
+
+module.exports = Eml2Pdf = function (filename) {
+    const entities = new Entities();
+    var eml2pdf = this;
+    this.email;
+    this.emlfilename = filename;
+    this.emailheader;
+    this.textmessage;
+    this.htmlmessage;
+    this.attachments = Array();
+
+    this.getEnvelope = function() {
+        if (eml2pdf.email != undefined) return;
+        var data = fs.readFileSync(this.emlfilename);
+        data = data.toString();
+        if (data.indexOf("\r\n") === -1) {
+            // fix newlines in eml files from apple mail app
+            data = data.replace(/\n/gi,"\r\n");
+        }
+
+        eml2pdf.email = new Envelope(data);
+    }
+
+    this.getEmlPath = function() {
+        return path.dirname(eml2pdf.emlfilename) + "/"
+            + sanitize(
+                dateFormat(eml2pdf.email['header']['date'], "yyyy.mm.dd") + " - " 
+                + eml2pdf.email['header']['from']['name'] + " - " 
+                + eml2pdf.email['header']['subject']
+            );
+    }
+
+    this.renameFile = function() {
+        return new Promise((resolve,reject) => {
+            eml2pdf.getEnvelope();
+
+            newname = eml2pdf.getEmlPath();
+            
+            if (this.emlfilename !== newname + ".eml") {
+    
+                if (fs.existsSync(newname + ".eml")) {
+                    let i = 1;
+                    while (fs.existsSync(newname + "_" + i + ".eml")) {
+                        i++;
+                    }
+                    newname = newname + "_" + i;
+                }
+    
+                fs.renameSync(this.emlfilename, newname + ".eml");
+                this.emlfilename = newname;
+                resolve(newname);
+            } else {
+                this.emlfilename = newname;
+                resolve(newname);
+            }
+        });
+    }
+    
+    this.parseEnvelope = function(envelope,callback) {
+        return new Promise((resolveParseEnvelope,reject) => {
+            let callbacksStarted = 0;
+            let callbacksProcessed = 0;
+
+
+
+            const done = function () {
+                if (callbacksStarted === callbacksProcessed) resolveParseEnvelope();
+            };
+            var iterator = function(envelope,callback) {
+                if (envelope.header.contentType === undefined) {
+                    // plaintext only mail
+                    eml2pdf.textmessage = envelope[0];
+                    done();
+                } else {
+                    // most likely multipart mail
+                    for (let prop in envelope) {
+
+                        if (Object.keys(envelope).length > 2) {
+
+                            if (envelope[prop]['header'] !== undefined) {
+                                // if this Envelope contains more Envelopes
+                                if (envelope[prop]['0'] instanceof Envelope) {
+                                    iterator(envelope[prop], callback);
+                                } else {
+                                    callbacksStarted++;
+                                    // run callback when no child Envelopes in this Envelope
+                                    callback(envelope[prop]).then(function () {
+                                        callbacksProcessed++;
+                                        done();
+                                    });
+
+                                }
+                            }
+                        } else {
+                            callback(envelope).then(function () {
+                                done();
+                            });
+                        }
+                    }
+                }
+            };
+            iterator(envelope,callback);
+        });
+    };
+
+    this.saveAttachmentsFromEML = function() {
+        return new Promise((resolve,reject) => {
+            eml2pdf.getEnvelope();
+
+            eml2pdf.parseEnvelope(eml2pdf.email,eml2pdf.checkForAttachment).then(function() {
+                resolve();
+            });
+        });
+    };
+
+    this.checkForAttachment = function(envelope) {
+        return new Promise((resolve,reject) => {
+            if (envelope.header.contentType.name) {
+                var filename = envelope.header.contentType.name;
+                var filepath = eml2pdf.getEmlPath() + "/";
+
+                if (!fs.existsSync(filepath)) {
+                    fs.mkdirSync(filepath);
+                }
+
+                fs.writeFile(filepath + filename, envelope['0'], function (err) {
+                    if (err) {
+                        console.log(err);
+                        reject();
+                    } else {
+                        resolve();
+                    }
+                });
+            } else {
+                resolve();
+            }
+        });
+    };
+
+     this.convertEMLtoPDF = function(){
+        return new Promise((resolve,reject) => {
+            eml2pdf.getEnvelope();
+
+
+            function getMessagebyFormat(envelope) {
+                return new Promise((resolve, reject) => {
+                    switch (envelope.header.contentType.mime) {
+                        case "text/plain":
+                            eml2pdf.textmessage = envelope[0];
+                            break;
+                        case "text/html":
+                            eml2pdf.htmlmessage = envelope[0];
+                            break;
+                    }
+                    if (
+                        envelope.header.contentDisposition &&
+                        ["attachment", "inline"].includes(envelope.header.contentDisposition.mime) &&
+                        envelope['header']['contentId']
+                        ) {
+                        eml2pdf.attachments.push({
+                            fileName: envelope['header']['contentType']['name'],
+                            contentId: envelope['header']['contentId'].replace('\>', '').replace('\<', ''),
+                            content: envelope['0']
+                        });
+                    }
+                    resolve();
+                });
+            }
+
+            eml2pdf.parseEnvelope(eml2pdf.email, getMessagebyFormat).then(() => {
+                if (eml2pdf.htmlmessage === undefined) {
+                    // settle with plain text version of message
+                    rawsource = '<p>' + entities.encode(eml2pdf.textmessage).replace(/\n{2,}/g, "</p><p>").replace(/\n/g, "<br>") + '</p>';
+                    ;
+                } else {
+                    // we have a formatted html message
+                    // inline images in the message
+                    rawsource = eml2pdf.inlineImages();
+                }
+                eml2pdf.generateEmailHeader();
+                var message = eml2pdf.emailheader;
+
+                message = message.concat(rawsource);
+
+                var options = {
+                    // format: 'A4',
+                    // zoomFactor: "1",
+                    width: "280mm", // * 4/3, // avoid pantomjs bug
+                    height: "396mm", // * 4/3 // avoid pantomjs bug
+                    border: "1cm"
+                };
+                let pdffilename = eml2pdf.emlfilename + ".pdf";
+
+                eml2pdf.writepdffile(message, pdffilename, options).then((result) => {
+                    resolve(result);
+                });
+            });
+        });
+    };
+
+    this.generateEmailHeader = function() {
+        var source = `<div style="font-family: -apple-system, BlinkMacSystemFont, sans-serif;font-size:15px;line-height: 1.3em">
+        <div>{{from}}</div>
+        <div style="font-size:12px;color:silver;">{{date}}</div>
+        <div style="font-size:12px;color:silver;">To: {{to}}</div>
+        {{#if cc}}
+        <div style="font-size:12px;color:silver;">Cc: {{cc}}</div>
+        {{/if}}
+        {{#if replyTo}}
+        <div style="font-size:12px;color:silver;">Reply-To: {{replyTo}}</div>
+        {{/if}}
+        <div style="font-size:12px;">{{subject}}</div>
+        <hr style="border:none; border-top:1px solid silver;">
+    </div>`;
+
+        var template = Handlebars.compile(source);
+        var data = {
+            from: eml2pdf.email.header.from.address,
+            date: eml2pdf.email.header.date,
+            to: eml2pdf.email.header.to.address,
+            subject: eml2pdf.email.header.subject,
+        };
+        if (eml2pdf.email.header.cc) {
+            data.cc = eml2pdf.email.header.cc.address;
+        }
+
+        if (eml2pdf.email.header.replyTo) {
+            data.replyTo = eml2pdf.email.header.replyTo.address;
+        }
+
+        eml2pdf.emailheader = template(data);
+    }
+
+    this.inlineImages = function() {
+        if (eml2pdf.attachments.length > 0){
+            return cid(eml2pdf.htmlmessage, eml2pdf.attachments.map((attachment, i) => ({ ...attachment, fileName: attachment.fileName || i.toString() })));
+        } else {
+            return eml2pdf.htmlmessage;
+        }
+    };
+
+    this.writepdffile = function(html,pdffilename,options) {
+        return new Promise((resolve, reject) => {
+            // Generate PDF
+            pdf.create(html, options).toFile(pdffilename, function (err, res) {
+                if (err) return reject(err);
+                resolve(res);
+            });
+        });
+    }
+}

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ module.exports = Eml2Pdf = function (filename) {
 
     this.inlineImages = function() {
         if (eml2pdf.attachments.length > 0){
-            return cid(eml2pdf.htmlmessage, eml2pdf.attachments);
+            return cid(eml2pdf.htmlmessage, eml2pdf.attachments.map((attachment, i) => ({ ...attachment, fileName: attachment.fileName || i.toString() })));
         } else {
             return eml2pdf.htmlmessage;
         }

--- a/index.js
+++ b/index.js
@@ -1,260 +1,54 @@
-var fs = require( 'fs' );
-var pdf = require( 'html-pdf' );
-var Envelope = require( 'envelope' );
-var path = require('path');
-var sanitize = require("sanitize-filename");
-var dateFormat = require('dateformat');
-var cid = require('npm-cid');
-var Handlebars = require('handlebars');
-const Entities = require('html-entities').AllHtmlEntities;
+#!/usr/bin/env node
 
-module.exports = Eml2Pdf = function (filename) {
-    const entities = new Entities();
-    var eml2pdf = this;
-    this.email;
-    this.emlfilename = filename;
-    this.emailheader;
-    this.textmessage;
-    this.htmlmessage;
-    this.attachments = Array();
+const fs = require("fs");
+const path = require("path");
 
-    this.getEnvelope = function() {
-        if (eml2pdf.email != undefined) return;
-        var data = fs.readFileSync(this.emlfilename);
-        data = data.toString();
-        if (data.indexOf("\r\n") === -1) {
-            // fix newlines in eml files from apple mail app
-            data = data.replace(/\n/gi,"\r\n");
-        }
+const Eml2Pdf = require("./eml-to-pdf");
 
-        eml2pdf.email = new Envelope(data);
-    }
+if (require.main === module) {
+  const emlPath = process.argv[2];
 
-    this.getEmlPath = function() {
-        return path.dirname(eml2pdf.emlfilename) + "/"
-            + sanitize(
-                dateFormat(eml2pdf.email['header']['date'], "yyyy.mm.dd") + " - " 
-                + eml2pdf.email['header']['from']['name'] + " - " 
-                + eml2pdf.email['header']['subject']
-            );
-    }
+  if (!fs.existsSync(emlPath)) {
+    console.error(
+      "Please specify a valid EML file path, or a directory path containing EML files"
+    );
+    process.exit(1);
+  }
 
-    this.renameFile = function() {
-        return new Promise((resolve,reject) => {
-            eml2pdf.getEnvelope();
+  if (fs.lstatSync(emlPath).isDirectory()) {
+    const files = fs.readdirSync(emlPath);
+    const emlFiles = files
+      .filter(Boolean)
+      .filter((file) => file.endsWith(".eml"))
+      .map((file) => path.join(emlPath, file));
+    recurseDir(emlFiles);
+  } else {
+    convertToPDF(emlPath);
+  }
+} else {
+  module.exports = Eml2Pdf;
+}
 
-            newname = eml2pdf.getEmlPath();
-            
-            if (this.emlfilename !== newname + ".eml") {
-    
-                if (fs.existsSync(newname + ".eml")) {
-                    let i = 1;
-                    while (fs.existsSync(newname + "_" + i + ".eml")) {
-                        i++;
-                    }
-                    newname = newname + "_" + i;
-                }
-    
-                fs.renameSync(this.emlfilename, newname + ".eml");
-                this.emlfilename = newname;
-                resolve(newname);
-            } else {
-                this.emlfilename = newname;
-                resolve(newname);
-            }
-        });
-    }
-    
-    this.parseEnvelope = function(envelope,callback) {
-        return new Promise((resolveParseEnvelope,reject) => {
-            let callbacksStarted = 0;
-            let callbacksProcessed = 0;
+function recurseDir(files) {
+  const emlFile = files[0];
+  if (emlFile) {
+    console.log(`Processing ${emlFile}`);
 
+    convertToPDF(emlFile).finally(() => {
+      recurse(files.slice(1));
+    });
+  }
+}
 
+function convertToPDF(emlFile) {
+  var eml2pdf = new Eml2Pdf(emlFile);
 
-            const done = function () {
-                if (callbacksStarted === callbacksProcessed) resolveParseEnvelope();
-            };
-            var iterator = function(envelope,callback) {
-                if (envelope.header.contentType === undefined) {
-                    // plaintext only mail
-                    eml2pdf.textmessage = envelope[0];
-                    done();
-                } else {
-                    // most likely multipart mail
-                    for (let prop in envelope) {
-
-                        if (Object.keys(envelope).length > 2) {
-
-                            if (envelope[prop]['header'] !== undefined) {
-                                // if this Envelope contains more Envelopes
-                                if (envelope[prop]['0'] instanceof Envelope) {
-                                    iterator(envelope[prop], callback);
-                                } else {
-                                    callbacksStarted++;
-                                    // run callback when no child Envelopes in this Envelope
-                                    callback(envelope[prop]).then(function () {
-                                        callbacksProcessed++;
-                                        done();
-                                    });
-
-                                }
-                            }
-                        } else {
-                            callback(envelope).then(function () {
-                                done();
-                            });
-                        }
-                    }
-                }
-            };
-            iterator(envelope,callback);
-        });
-    };
-
-    this.saveAttachmentsFromEML = function() {
-        return new Promise((resolve,reject) => {
-            eml2pdf.getEnvelope();
-
-            eml2pdf.parseEnvelope(eml2pdf.email,eml2pdf.checkForAttachment).then(function() {
-                resolve();
-            });
-        });
-    };
-
-    this.checkForAttachment = function(envelope) {
-        return new Promise((resolve,reject) => {
-            if (envelope.header.contentType.name) {
-                var filename = envelope.header.contentType.name;
-                var filepath = eml2pdf.getEmlPath() + "/";
-
-                if (!fs.existsSync(filepath)) {
-                    fs.mkdirSync(filepath);
-                }
-
-                fs.writeFile(filepath + filename, envelope['0'], function (err) {
-                    if (err) {
-                        console.log(err);
-                        reject();
-                    } else {
-                        resolve();
-                    }
-                });
-            } else {
-                resolve();
-            }
-        });
-    };
-
-     this.convertEMLtoPDF = function(){
-        return new Promise((resolve,reject) => {
-            eml2pdf.getEnvelope();
-
-
-            function getMessagebyFormat(envelope) {
-                return new Promise((resolve, reject) => {
-                    switch (envelope.header.contentType.mime) {
-                        case "text/plain":
-                            eml2pdf.textmessage = envelope[0];
-                            break;
-                        case "text/html":
-                            eml2pdf.htmlmessage = envelope[0];
-                            break;
-                    }
-                    if (
-                        envelope.header.contentDisposition &&
-                        ["attachment", "inline"].includes(envelope.header.contentDisposition.mime) &&
-                        envelope['header']['contentId']
-                        ) {
-                        eml2pdf.attachments.push({
-                            fileName: envelope['header']['contentType']['name'],
-                            contentId: envelope['header']['contentId'].replace('\>', '').replace('\<', ''),
-                            content: envelope['0']
-                        });
-                    }
-                    resolve();
-                });
-            }
-
-            eml2pdf.parseEnvelope(eml2pdf.email, getMessagebyFormat).then(() => {
-                if (eml2pdf.htmlmessage === undefined) {
-                    // settle with plain text version of message
-                    rawsource = '<p>' + entities.encode(eml2pdf.textmessage).replace(/\n{2,}/g, "</p><p>").replace(/\n/g, "<br>") + '</p>';
-                    ;
-                } else {
-                    // we have a formatted html message
-                    // inline images in the message
-                    rawsource = eml2pdf.inlineImages();
-                }
-                eml2pdf.generateEmailHeader();
-                var message = eml2pdf.emailheader;
-
-                message = message.concat(rawsource);
-
-                var options = {
-                    // format: 'A4',
-                    // zoomFactor: "1",
-                    width: "280mm", // * 4/3, // avoid pantomjs bug
-                    height: "396mm", // * 4/3 // avoid pantomjs bug
-                    border: "1cm"
-                };
-                let pdffilename = eml2pdf.emlfilename + ".pdf";
-
-                eml2pdf.writepdffile(message, pdffilename, options).then((result) => {
-                    resolve(result);
-                });
-            });
-        });
-    };
-
-    this.generateEmailHeader = function() {
-        var source = `<div style="font-family: -apple-system, BlinkMacSystemFont, sans-serif;font-size:15px;line-height: 1.3em">
-        <div>{{from}}</div>
-        <div style="font-size:12px;color:silver;">{{date}}</div>
-        <div style="font-size:12px;color:silver;">To: {{to}}</div>
-        {{#if cc}}
-        <div style="font-size:12px;color:silver;">Cc: {{cc}}</div>
-        {{/if}}
-        {{#if replyTo}}
-        <div style="font-size:12px;color:silver;">Reply-To: {{replyTo}}</div>
-        {{/if}}
-        <div style="font-size:12px;">{{subject}}</div>
-        <hr style="border:none; border-top:1px solid silver;">
-    </div>`;
-
-        var template = Handlebars.compile(source);
-        var data = {
-            from: eml2pdf.email.header.from.address,
-            date: eml2pdf.email.header.date,
-            to: eml2pdf.email.header.to.address,
-            subject: eml2pdf.email.header.subject,
-        };
-        if (eml2pdf.email.header.cc) {
-            data.cc = eml2pdf.email.header.cc.address;
-        }
-
-        if (eml2pdf.email.header.replyTo) {
-            data.replyTo = eml2pdf.email.header.replyTo.address;
-        }
-
-        eml2pdf.emailheader = template(data);
-    }
-
-    this.inlineImages = function() {
-        if (eml2pdf.attachments.length > 0){
-            return cid(eml2pdf.htmlmessage, eml2pdf.attachments.map((attachment, i) => ({ ...attachment, fileName: attachment.fileName || i.toString() })));
-        } else {
-            return eml2pdf.htmlmessage;
-        }
-    };
-
-    this.writepdffile = function(html,pdffilename,options) {
-        return new Promise((resolve, reject) => {
-            // Generate PDF
-            pdf.create(html, options).toFile(pdffilename, function (err, res) {
-                if (err) return reject(err);
-                resolve(res);
-            });
-        });
-    }
+  return eml2pdf
+    .convertEMLtoPDF()
+    .then((output) => {
+      console.log(output);
+    })
+    .catch((err) => {
+      console.error(err);
+    });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -73,6 +74,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -98,7 +100,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "optional": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -126,7 +129,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "optional": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -174,7 +178,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "optional": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -317,7 +322,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -352,7 +358,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -411,7 +418,8 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "optional": true
     },
     "mime-lib": {
       "version": "0.5.3",
@@ -426,6 +434,7 @@
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "optional": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -618,7 +627,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "optional": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -708,7 +718,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.8",
   "description": "Convert EML files to PDF, save attachments, rename EML files",
   "main": "index.js",
+  "bin": "index.js",
   "dependencies": {
     "dateformat": "^3.0.3",
     "envelope": "^2.0.2",


### PR DESCRIPTION
With this PR, this package can be either required, or installed and used as a global NPM package i.e.

```sh
npm i -g eml-to-pdf

eml-to-pdf <path-to-eml-file>
eml-to-pdf <path-to-directory-containing-eml-files>
```